### PR TITLE
1 discussions why the length in boot stage2ld is equal 254

### DIFF
--- a/00_asm_blink/boot_stage2.ld
+++ b/00_asm_blink/boot_stage2.ld
@@ -1,7 +1,7 @@
 MEMORY {
     /* We are loaded to the top 256 bytes of SRAM, which is above the bootrom
        stack. Note 4 bytes occupied by checksum. */
-    SRAM(rx) : ORIGIN = 0x20040000, LENGTH = 254
+    SRAM(rx) : ORIGIN = 0x20040000, LENGTH = 252
 }
 
 SECTIONS {

--- a/01_c_blink/boot_stage2.ld
+++ b/01_c_blink/boot_stage2.ld
@@ -1,7 +1,7 @@
 MEMORY {
     /* We are loaded to the top 256 bytes of SRAM, which is above the bootrom
        stack. Note 4 bytes occupied by checksum. */
-    SRAM(rx) : ORIGIN = 0x20040000, LENGTH = 254
+    SRAM(rx) : ORIGIN = 0x20040000, LENGTH = 252
 }
 
 SECTIONS {


### PR DESCRIPTION
Fixing SRAM length