### PR TITLE
Revert "Update XIP_SSI_CTRLR1 setting in boot2.s in all directories"

### DIFF
--- a/06_uart/uart_blocking.c
+++ b/06_uart/uart_blocking.c
@@ -107,7 +107,7 @@ static void uartTxStr( unsigned char *x )
     while( *x != '\0' )
     {
         uartTx( *x );
-        x++;
+        *x++;
     }
 }
 

--- a/07_multicore/multicore.c
+++ b/07_multicore/multicore.c
@@ -162,7 +162,7 @@ static void uartTxStr( unsigned char *x )
     while( *x != '\0' )
     {
         uartTx( *x );
-        x++;
+        *x++;
     }
 }
 

--- a/08_uart_cmsis/uart_blocking.c
+++ b/08_uart_cmsis/uart_blocking.c
@@ -65,7 +65,7 @@ static void uartTxStr( unsigned char *x )
     while( *x != '\0' )
     {
         uartTx( *x );
-        x++;
+        *x++;
     }
 }
 

--- a/09_i2c_blocking/uart.c
+++ b/09_i2c_blocking/uart.c
@@ -40,7 +40,7 @@ void uartTxStr( unsigned char *x )
     while( *x != '\0' )
     {
         uartTx( *x );
-        x++;
+        *x++;
     }
 }
 

--- a/12_uart_irq/uart.c
+++ b/12_uart_irq/uart.c
@@ -48,7 +48,7 @@ void uartTxStr( unsigned char *x )
     while( *x != '\0' )
     {
         uartTx( *x );
-        x++;
+        *x++;
     }
 }
 

--- a/13_adc_temp/uart.c
+++ b/13_adc_temp/uart.c
@@ -40,7 +40,7 @@ void uartTxStr( unsigned char *x )
     while( *x != '\0' )
     {
         uartTx( *x );
-        x++;
+        *x++;
     }
 }
 

--- a/14_bootrom_func_data/uart.c
+++ b/14_bootrom_func_data/uart.c
@@ -40,7 +40,7 @@ void uartTxStr( unsigned char *x )
     while( *x != '\0' )
     {
         uartTx( *x );
-        x++;
+        *x++;
     }
 }
 


### PR DESCRIPTION
Reverts carlosftm/RPi-Pico-Baremetal#3

Merged by mistake. Reason for rejecting is that the destination register is r1 and not r0.